### PR TITLE
Enable use of Vim's quickfix window and jump to build error features

### DIFF
--- a/autoload/bazel.vim
+++ b/autoload/bazel.vim
@@ -30,7 +30,7 @@ function! bazel#Run(arguments) abort
     set errorformat+=%-GLoading:\ %.%#
     set errorformat+=%-G[%.%#
 
-    execute "set makeprg=bazel\\ build\\" join(a:arguments[1:100])
+    execute "set makeprg=bazel\\ build\\" substitute(join(a:arguments[1:100]), ' ', '\\ ', 'g')
     make
   else
     let l:syscall = maktaba#syscall#Create(['bazel'] + a:arguments)

--- a/autoload/bazel.vim
+++ b/autoload/bazel.vim
@@ -21,8 +21,21 @@ function! bazel#Run(arguments) abort
   call s:PLUGIN.logger.Info(
       \ 'Invoking bazel with arguments "%s"', string(a:arguments))
   call s:Autowrite()
-  let l:syscall = maktaba#syscall#Create(['bazel'] + a:arguments)
-  call l:syscall.CallForeground(1, 0)
+  if a:arguments[0] == "build"
+    set errorformat=ERROR:\ %f:%l:%c:%m
+    set errorformat+=%f:%l:%c:%m
+
+    " Ignore build output lines starting with INFO:, Loading:, or [
+    set errorformat+=%-GINFO:\ %.%#
+    set errorformat+=%-GLoading:\ %.%#
+    set errorformat+=%-G[%.%#
+
+    execute "set makeprg=bazel\\ build\\" join(a:arguments[1:100])
+    make
+  else
+    let l:syscall = maktaba#syscall#Create(['bazel'] + a:arguments)
+    call l:syscall.CallForeground(1, 0)
+  endif
   " Note: Intentionally doesn't check v:shell_error.
   " Errors are printed on console by bazel, and visible until explicitly
   " dismissed because we use CallForeground in pause mode.


### PR DESCRIPTION
This change allows the use of vim's built in quickfix window with Bazel build. For example, the vim command `:Bazel build //whatever:thing` still builds as before, however, you can run `:cwindow` to see the errors and jump to them after the build finishes. It also sets `makeprg` so you can then quickly rerun the same build by simply invoking `:make`. This is especially convenient since existing macros that use `:make` to initiate a build now work sensibly in this context.

I've also seen the discussion on https://github.com/bazelbuild/vim-bazel/issues/1 about how vim's error parsing isn't up to the task here.  However, I haven't found there to be any issues. I did need to modify the default `errorformat` parsing rules in vim a bit, but with some minor tweaks they are parsing compiler errors just fine.  I did only test it with gcc on linux, so maybe the issues being discussed in #1 are with regards to some other setup. 