### PR TITLE
Change bazel#Run to take a config to that can override executable.

### DIFF
--- a/autoload/bazel/workspace.vim
+++ b/autoload/bazel/workspace.vim
@@ -1,8 +1,5 @@
-""
-" @section Introduction, intro
-" @library
-" Implements common path functionality used by bazel-related plugins.  For
-" more details about Build file structure/terminology, see:
+" Common path functionality used by bazel-related plugins.  For more details
+" about Build file structure/terminology, see:
 " https://bazel.build/versions/master/docs/build-ref.html
 
 ""

--- a/doc/bazel.txt
+++ b/doc/bazel.txt
@@ -6,6 +6,7 @@ CONTENTS                                                      *bazel-contents*
   1. Introduction................................................|bazel-intro|
   2. Configuration..............................................|bazel-config|
   3. Commands.................................................|bazel-commands|
+  4. Functions...............................................|bazel-functions|
 
 ==============================================================================
 INTRODUCTION                                                     *bazel-intro*
@@ -34,6 +35,32 @@ COMMANDS                                                      *bazel-commands*
   bazel is invoked.
 
   Supports tab completion.
+
+==============================================================================
+FUNCTIONS                                                    *bazel-functions*
+
+The plugin provides a few helper functions to be used in custom integrations
+and specialized user configuration.
+
+bazel#Run({arguments}, [config])                                 *bazel#Run()*
+  Executes a bazel command with {arguments} and optional [config].
+
+  [config] currently accepts a key "executable" to override the default
+  executable of "bazel" (example: `{'executable': 'blaze'}`).
+
+  Normally this is invoked by the |:Bazel| command. It's available as a
+  function so it can be used in custom plugin integrations and commands. For
+  example, this config defines a command to invoke an alternate bazel
+  executable:
+>
+    command -nargs=* -complete=customlist,bazel#CompletionList Blaze
+        \ call bazel#Run([<f-args>], {'executable': 'blaze'})
+<
+
+bazel#CompletionList({unused_arg}, {line}, {pos})     *bazel#CompletionList()*
+  Completions for the |:Bazel| command and similar custom commands.
+
+  Completions are extracted from the bash bazel completion function.
 
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/vroom/bazel.vroom
+++ b/vroom/bazel.vroom
@@ -12,3 +12,12 @@ prompt until explicitly dismissed.
   :Bazel info <CR>
   ! bazel info
   $ workspace: /some/path
+
+
+For advanced usage scenarios, it can also be invoked via the bazel#Run function,
+which allows some custom configuration to be passed to the invocation. You can
+use it to invoke an alternate executable name.
+
+  :call bazel#Run(['info'], {'executable': 'blaze'}) <CR>
+  ! blaze info
+  $ workspace: /some/path


### PR DESCRIPTION
This can be used to integrate with bazel from other plugins or to define an
alternate command that invokes a bazel workalike with a different name, e.g.
"blaze".