### PR TITLE
Update vroom tests to run for neovim and oldest supported maktaba

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
     - VROOM_VERSION=0.14.0
   jobs:
     # This Maktaba version should match the minimum required in instant/flags.vim.
+    - CI_TARGET=vim MAKTABA_VERSION=1.12.0
     - CI_TARGET=vim MAKTABA_VERSION=master
     - CI_TARGET=neovim MAKTABA_VERSION=master
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: generic
 env:
-  matrix:
+  global:
+    - VROOM_VERSION=0.14.0
+  jobs:
     # This Maktaba version should match the minimum required in instant/flags.vim.
     - CI_TARGET=vim MAKTABA_VERSION=master
     - CI_TARGET=neovim MAKTABA_VERSION=master
@@ -11,12 +13,12 @@ before_script:
       sudo apt-get install vim-gnome;
     elif [ $CI_TARGET = neovim ]; then
       eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64" &&
-      wget https://bootstrap.pypa.io/get-pip.py &&
-      sudo python3 get-pip.py --allow-external sudo &&
+      wget https://bootstrap.pypa.io/3.5/get-pip.py &&
+      sudo python3 get-pip.py &&
       sudo pip3 install neovim;
     fi
-  - wget https://github.com/google/vroom/releases/download/v0.12.0/vroom_0.12.0-1_all.deb
-  - sudo dpkg -i ./vroom_0.12.0-1_all.deb
+  - wget https://github.com/google/vroom/releases/download/v${VROOM_VERSION}/vroom_${VROOM_VERSION}-1_all.deb
+  - sudo dpkg -i ./vroom_${VROOM_VERSION}-1_all.deb
   - git clone -b ${MAKTABA_VERSION} https://github.com/google/vim-maktaba.git ../maktaba/
   - git clone https://github.com/google/vim-glaive.git ../glaive/
 services:
@@ -24,7 +26,5 @@ services:
 script:
   - '[ $CI_TARGET = neovim ] && VROOM_ARGS="--neovim" || VROOM_ARGS=""'
   - vroom $VROOM_ARGS --crawl ./vroom/
-matrix:
+jobs:
   fast_finish: true
-  allow_failures:
-    - env: CI_TARGET=neovim MAKTABA_VERSION=master

--- a/bootstrap.vim
+++ b/bootstrap.vim
@@ -1,0 +1,61 @@
+" Copyright 2021 Google Inc. All rights reserved.
+"
+" Licensed under the Apache License, Version 2.0 (the "License");
+" you may not use this file except in compliance with the License.
+" You may obtain a copy of the License at
+"
+"     http://www.apache.org/licenses/LICENSE-2.0
+"
+" Unless required by applicable law or agreed to in writing, software
+" distributed under the License is distributed on an "AS IS" BASIS,
+" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+" See the License for the specific language governing permissions and
+" limitations under the License.
+
+" This file can be sourced to install the plugin and its dependencies if no
+" plugin manager is available.
+
+let s:thisplugin = expand('<sfile>:p:h')
+if !exists('*maktaba#compatibility#Disable')
+  try
+    " To check if Maktaba is loaded we must try calling a maktaba function.
+    " exists() is false for autoloadable functions that are not yet loaded.
+    call maktaba#compatibility#Disable()
+  catch /E117:/
+    " Maktaba is not installed. Check whether it's in a nearby directory.
+    let s:rtpsave = &runtimepath
+    " We'd like to use maktaba#path#Join, but maktaba doesn't exist yet.
+    let s:slash = exists('+shellslash') && !&shellslash ? '\' : '/'
+    let s:guess1 = fnamemodify(s:thisplugin, ':h') . s:slash . 'maktaba'
+    let s:guess2 = fnamemodify(s:thisplugin, ':h') . s:slash . 'vim-maktaba'
+    if isdirectory(s:guess1)
+      let &runtimepath .= ',' . s:guess1
+    elseif isdirectory(s:guess2)
+      let &runtimepath .= ',' . s:guess2
+    endif
+
+    try
+      " If we've just installed maktaba, we need to make sure that vi
+      " compatibility mode is off. Maktaba does not support vi compatibility.
+      call maktaba#compatibility#Disable()
+    catch /E117:/
+      " No luck.
+      let &runtimepath = s:rtpsave
+      unlet s:rtpsave
+      " We'd like to use maktaba#error#Shout, but maktaba doesn't exist yet.
+      echohl ErrorMsg
+      echomsg 'Maktaba not found! Bazel depends upon maktaba. Please either:'
+      echomsg '1. Place maktaba in the same directory as this plugin.'
+      echomsg '2. Add maktaba to your runtimepath before using this plugin.'
+      echomsg 'Maktaba can be found at http://github.com/google/vim-maktaba.'
+      echohl NONE
+      finish
+    endtry
+  endtry
+endif
+if !maktaba#IsAtLeastVersion('1.12.0')
+  call maktaba#error#Shout('Bazel requires maktaba version 1.12.0.')
+  call maktaba#error#Shout('You have maktaba version %s.', maktaba#VERSION)
+  call maktaba#error#Shout('Please update your maktaba install.')
+endif
+let s:plugin = maktaba#plugin#GetOrInstall(s:thisplugin)

--- a/vroom/bazel.vroom
+++ b/vroom/bazel.vroom
@@ -9,15 +9,20 @@ The main command this plugin provides is :Bazel, which drops to a shell and
 invokes bazel in the foreground, leaving output visible with a "Press ENTER"
 prompt until explicitly dismissed.
 
-  :Bazel info <CR>
+  :Bazel info <CR> (0.5s)
   ! bazel info
   $ workspace: /some/path
+
+Note: If it looks strange, the <CR> above is to dismiss the "Press ENTER"
+prompt. The extra 0.5s delay avoids failures that can happen in certain
+configurations (see
+https://github.com/google/vroom/issues/2#issuecomment-770320120).
 
 
 For advanced usage scenarios, it can also be invoked via the bazel#Run function,
 which allows some custom configuration to be passed to the invocation. You can
 use it to invoke an alternate executable name.
 
-  :call bazel#Run(['info'], {'executable': 'blaze'}) <CR>
+  :call bazel#Run(['info'], {'executable': 'blaze'}) <CR> (0.5s)
   ! blaze info
   $ workspace: /some/path

--- a/vroom/setupvroom.vim
+++ b/vroom/setupvroom.vim
@@ -15,8 +15,12 @@
 " This file is used from vroom scripts to bootstrap the bazel plugin and
 " configure it to work properly under vroom.
 
-" Codereview does not support compatible mode.
+" Bazel does not support compatible mode.
 set nocompatible
+
+" Set cmdheight to avoid getting stuck at "Hit ENTER to continue" prompts,
+" particularly in neovim mode.
+set cmdheight=5
 
 " Install maktaba from local dir.
 let s:repo = expand('<sfile>:p:h:h')

--- a/vroom/setupvroom.vim
+++ b/vroom/setupvroom.vim
@@ -22,24 +22,12 @@ set nocompatible
 " particularly in neovim mode.
 set cmdheight=5
 
-" Install maktaba from local dir.
-let s:repo = expand('<sfile>:p:h:h')
-let s:search_dir = fnamemodify(s:repo, ':h')
-" We'd like to use maktaba#path#Join, but maktaba doesn't exist yet.
-let s:slash = exists('+shellslash') && !&shellslash ? '\' : '/'
-for s:plugin_dirname in ['maktaba', 'vim-maktaba']
-  let s:bootstrap_path = join([s:search_dir, s:plugin_dirname, 'bootstrap.vim'],
-      \ s:slash)
-  if filereadable(s:bootstrap_path)
-    execute 'source' s:bootstrap_path
-    break
-  endif
-endfor
-
-" Install the bazel plugin.
-call maktaba#plugin#GetOrInstall(s:repo)
+" Install bazel plugin and its dependencies.
+let s:repo = fnamemodify($VROOMDIR, ':p:h:h')
+execute 'source' s:repo . '/bootstrap.vim'
 
 " Install Glaive from local dir.
+let s:search_dir = fnamemodify(s:repo, ':h')
 for s:plugin_dirname in ['glaive', 'vim-glaive']
   let s:bootstrap_path =
       \ maktaba#path#Join([s:search_dir, s:plugin_dirname, 'bootstrap.vim'])


### PR DESCRIPTION
Specific changes:
  * Fixes get-pip errors in .travis.yml, removes allow_failures, and renames legacy "matrix" field to "jobs".
  * Applies `set cmdheight=5` workaround to avoid vroom neovim mode getting stuck.
  * Adds some vroom delays to fix neovim mode failures.
  * Updates to use vroom 0.14.0.
  * Adds testing job configured for oldest supported maktaba version (1.12.0).
  * Consolidates some plugin setup used in vroom into bootstrap.vim.